### PR TITLE
Added shutdown command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import discord
 import os
 import logging

--- a/cogs/initial.py
+++ b/cogs/initial.py
@@ -40,5 +40,5 @@ class Initial(commands.Cog):
         if isinstance(error, commands.errors.CheckFailure):
             logger.warning('Check failure occurred.')
         else:
-            logger.warning('Ignoring exception in command {}:'.format(ctx.command), file=sys.stderr)
+            logger.warning('Ignoring exception in command {}:'.format(ctx.command))
             traceback.print_exception(type(error), error, error.__traceback__, file=sys.stderr)

--- a/cogs/management.py
+++ b/cogs/management.py
@@ -2,6 +2,7 @@ from discord.ext import commands, tasks
 from discord import TextChannel
 from typing import Optional
 import os
+import time
 from .utils.db import (
     load_guild_db,
     add_guild_admin_channel,
@@ -145,3 +146,22 @@ class Management(commands.Cog):
             embed = get_settings_embed(ctx, guild_settings)
 
             await ctx.channel.send(embed=embed)
+
+    @commands.command(
+        help=(
+            "Shutdown the bot."
+        ),
+        brief="Shutdown the bot."
+    )
+    @commands.check(check_bot)
+    @commands.check(check_admin_channel)
+    @commands.check(check_admin)
+    async def shutdown(self, ctx):
+        """
+        Function to force the bot to shutdown.
+        """
+
+        await ctx.channel.send(
+            "Snorlax is shutting down."
+        )
+        await ctx.bot.logout()

--- a/cogs/management.py
+++ b/cogs/management.py
@@ -1,8 +1,7 @@
-from discord.ext import commands, tasks
-from discord import TextChannel
-from typing import Optional
 import os
-import time
+from typing import Optional
+from discord import TextChannel
+from discord.ext import commands, tasks
 from .utils.db import (
     load_guild_db,
     add_guild_admin_channel,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord.py>=1.4.1,<2.0
 pandas>=1.1.1,<1.2
+python-dotenv==0.15.0


### PR DESCRIPTION
This doesn't fix #12 as I was having trouble getting the log in to work after a logout.

If anyone knows how to fix it I'd appreciate an answer!
```
[2020-11-14 16:59:31] - INFO - Snorlax is in 1 guilds.
[2020-11-14 16:59:34] - INFO - Websocket closed with 1000, cannot reconnect.
[2020-11-14 16:59:34] - INFO - logging in using static token
[2020-11-14 16:59:34] - INFO - Cleaning up tasks.
[2020-11-14 16:59:34] - INFO - Cleaning up after 3 tasks.
[2020-11-14 16:59:34] - INFO - All tasks finished cancelling.
[2020-11-14 16:59:34] - INFO - Closing the event loop.
[2020-11-14 16:59:34] - ERROR - Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x11a85b8e0>
[2020-11-14 16:59:34] - ERROR - Exception in default exception handler
Traceback (most recent call last):
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/asyncio/base_events.py", line 1733, in call_exception_handler
    self.default_exception_handler(context)
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/asyncio/base_events.py", line 1707, in default_exception_handler
    logger.error('\n'.join(log_lines), exc_info=exc_info)
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 1463, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 1577, in _log
    self.handle(record)
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 1587, in handle
    self.callHandlers(record)
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 1649, in callHandlers
    hdlr.handle(record)
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 950, in handle
    self.emit(record)
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 1182, in emit
    self.stream = self._open()
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 1172, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding)
NameError: name 'open' is not defined
Exception ignored in: <function ClientSession.__del__ at 0x107945ee0>
Traceback (most recent call last):
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/site-packages/aiohttp/client.py", line 314, in __del__
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/asyncio/base_events.py", line 1740, in call_exception_handler
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 1463, in error
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 1577, in _log
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 1587, in handle
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 1649, in callHandlers
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 950, in handle
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 1182, in emit
  File "/Users/adam/anaconda3/envs/discord/lib/python3.8/logging/__init__.py", line 1172, in _open
NameError: name 'open' is not defined
```