### PR TITLE
Added support for Meowth dynamic raid channels

### DIFF
--- a/cogs/fc_filter.py
+++ b/cogs/fc_filter.py
@@ -10,6 +10,7 @@ from .utils.checks import (
     check_bot
 )
 from .utils.db import (
+    load_guild_db,
     load_friend_code_channels_db,
     add_allowed_friend_code_channel,
     drop_allowed_friend_code_channel
@@ -138,3 +139,32 @@ class FriendCodeFilter(commands.Cog):
                                 delete_after=60
                             )
                             await message.delete()
+
+
+    @commands.Cog.listener()
+    async def on_guild_channel_create(self, channel):
+        guild_db = load_guild_db()
+        guild_meowth_cat = guild_db.loc[channel.guild.id]['meowth_raid_category']
+        if guild_meowth_cat == -1:
+            pass
+        else:
+            if channel.category.id == guild_meowth_cat:
+                # Add the newly created channel to allow fc
+                ok = add_allowed_friend_code_channel(channel.guild, channel, "True")
+                # TODO Add logging here.
+            else:
+                pass
+
+    @commands.Cog.listener()
+    async def on_guild_channel_delete(self, channel):
+        guild_db = load_guild_db()
+        guild_meowth_cat = guild_db.loc[channel.guild.id]['meowth_raid_category']
+        if guild_meowth_cat == -1:
+            pass
+        else:
+            if channel.category.id == guild_meowth_cat:
+                # Add the newly created channel to allow fc
+                ok = drop_allowed_friend_code_channel(channel.guild, channel)
+                # TODO Add logging here.
+            else:
+                pass

--- a/cogs/management.py
+++ b/cogs/management.py
@@ -6,6 +6,7 @@ from .utils.db import (
     load_guild_db,
     add_guild_admin_channel,
     add_guild_tz,
+    add_guild_meowth_raid_category
 )
 from .utils.utils import get_current_time, get_settings_embed
 from .utils.checks import (
@@ -86,6 +87,41 @@ class Management(commands.Cog):
         else:
             msg = (
                 "Error when setting the admin channel."
+            )
+        await ctx.channel.send(msg)
+
+    @commands.command(
+        help=(
+            "Sets the Meowth raid category for the guild where Snorlax"
+            " will make sure not to eat friend codes in dynamically created"
+            " channels."
+        ),
+        brief="Set the meowth raid categry for the bot."
+    )
+    @commands.check(check_bot)
+    @commands.check(check_admin)
+    async def setMeowthRaidCategory(
+        self, ctx, category_id: int=-1):
+        """
+        Docstring goes here.
+        """
+        guild = ctx.guild
+        channel = guild.get_channel(category_id)
+        if channel == None:
+            ok = False
+        else:
+            cat_name = channel.name
+            ok = add_guild_meowth_raid_category(guild, channel)
+        if ok:
+            msg = (
+                "**{}** set as the Meowth raid category successfully."
+                " Make sure Snorlax has the correct permissions!".format(
+                    cat_name.upper()
+                )
+            )
+        else:
+            msg = (
+                "Error when setting the meowth raid channel."
             )
         await ctx.channel.send(msg)
 

--- a/cogs/utils/db.py
+++ b/cogs/utils/db.py
@@ -107,7 +107,7 @@ def add_guild_admin_channel(guild, channel):
 
         else:
             sql_command = (
-                """INSERT INTO guilds VALUES ({}, "{}", {});""".format(
+                """INSERT INTO guilds VALUES ({}, "{}", {}, -1);""".format(
                     guild.id, DEFAULT_TZ, channel.id
                 )
             )
@@ -147,6 +147,42 @@ def add_guild_tz(guild, tz):
             sql_command = (
                 """INSERT INTO guilds VALUES ({}, "{}", 0);""".format(
                     guild.id, tz
+                )
+            )
+            c.execute(sql_command)
+
+        conn.commit()
+        conn.close()
+
+        return True
+
+    except Exception as e:
+        return False
+
+
+def add_guild_meowth_raid_category(guild, category):
+    """
+    Sets the Meowth raid category for Meowth such that
+    the friend code filter can play nice with the created channels.
+    """
+    try:
+        conn = sqlite3.connect(DATABASE)
+        c = conn.cursor()
+        for row in c.execute(
+            "SELECT * FROM guilds WHERE id={}".format(guild.id)
+        ):
+            entry_id = row[0]
+            sql_command = (
+                "UPDATE guilds SET meowth_raid_category"
+                " = {} WHERE ID = {};".format(category.id, entry_id)
+            )
+            c.execute(sql_command)
+            break
+
+        else:
+            sql_command = (
+                """INSERT INTO guilds VALUES ({}, "{}", 0, {});""".format(
+                    guild.id, DEFAULT_TZ, category.id
                 )
             )
             c.execute(sql_command)

--- a/cogs/utils/utils.py
+++ b/cogs/utils/utils.py
@@ -80,6 +80,11 @@ def get_settings_embed(ctx, guild_settings):
     """
     Create an embed to show the schedules.
     """
+    if guild_settings['meowth_raid_category'] != -1:
+        cat_name = ctx.guild.get_channel(guild_settings['meowth_raid_category']).name
+    else:
+        cat_name = 'Not set'
+
     embed = Embed(
         title='Settings',
         color=16756290
@@ -89,9 +94,11 @@ def get_settings_embed(ctx, guild_settings):
         name="Guild Settings",
         value=(
             'TZ: **{}**\n'
-            'Admin Channel: **<#{}>**'.format(
+            'Admin Channel: **<#{}>**\n'
+            'Meowth Raid Category: **{}**'.format(
                 guild_settings['tz'],
-                guild_settings['admin_channel']
+                guild_settings['admin_channel'],
+                cat_name
             )
         ),
         inline=False

--- a/initdb.py
+++ b/initdb.py
@@ -31,7 +31,8 @@ c.execute(SQL_STATEMENT)
 SQL_STATEMENT = """CREATE TABLE guilds (
     id INTEGER PRIMARY KEY,
     tz VARCHAR(40),
-    admin_channel INTEGER
+    admin_channel INTEGER,
+    meowth_raid_category INTEGER
 );
 """
 


### PR DESCRIPTION
Adds a newly created raid channel to the allow friend code list, and then removes it when meowth deletes it.