### PR TITLE
Migrate guild times and default messages to DB

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -8,13 +8,13 @@ DEFAULT_CLOSE_MESSAGE="**Snorlax is blocking the path!**"
 DEFAULT_TZ="Australia/Sydney"
 
 # Time before warning.
-WARNING_TIME=20
+DEFAULT_WARNING_TIME=20
 
 # Time since last message for the channel to be considered inactive.
-INACTIVE_TIME=15
+DEFAULT_INACTIVE_TIME=15
 
 # Time to delay closure if channel is active.
-DELAY_TIME=10
+DEFAULT_DELAY_TIME=10
 
 # New joiner names that will be banned, enter with commas with no space
 # e.g. firstname,secondname

--- a/alembic/versions/9b7158520f28_create_guild_schedule_settings_table.py
+++ b/alembic/versions/9b7158520f28_create_guild_schedule_settings_table.py
@@ -1,0 +1,32 @@
+"""create guild_schedule_settings table
+
+Revision ID: 9b7158520f28
+Revises: c897b93f45ce
+Create Date: 2022-08-26 22:35:28.930715
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9b7158520f28'
+down_revision = 'c897b93f45ce'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'guild_schedule_settings',
+        sa.Column('guild', sa.Integer, sa.ForeignKey("guilds.id"), nullable=False),
+        sa.Column('base_open_message', sa.String(length=60), nullable=False),
+        sa.Column('base_close_message', sa.String(length=60), nullable=False),
+        sa.Column('warning_time', sa.Integer, nullable=False),
+        sa.Column('inactive_time', sa.Integer, nullable=False),
+        sa.Column('delay_time', sa.Integer, nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('guild_schedule_settings')

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -448,6 +448,7 @@ class Admin(commands.GroupCog, name="admin"):
         if await snorlax_checks.check_guild_exists(guild.id):
             logger.info(f'Setting guild {guild.name} to active.')
             ok = await snorlax_db.set_guild_active(guild.id, 1)
+
             # Then go through admin_channel, log_channel, time_channel, schedules
             # and raid category to see if the channels still exist. Reset or drop if they don't.
             admin_channel_id = await snorlax_db.get_guild_admin_channel(guild.id)

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -342,9 +342,16 @@ class Admin(commands.GroupCog, name="admin"):
             )
         else:
             guild_settings = guild_db.loc[guild_id]
-            embed = get_settings_embed(interaction.guild, guild_settings)
+            guild_schedule_settings = await snorlax_db.load_guild_schedule_settings(guild_id)
+            if guild_schedule_settings.empty:
+                await interaction.response.send_message(
+                    'Guild schedule settings failed to load! Contact admin.',
+                    ephemeral=True
+                )
+            else:
+                embed = get_settings_embed(interaction.guild, guild_settings, guild_schedule_settings)
 
-            await interaction.response.send_message(embed=embed)
+                await interaction.response.send_message(embed=embed)
 
     @commands.command(
         help=(

--- a/cogs/initial.py
+++ b/cogs/initial.py
@@ -6,7 +6,7 @@ import logging
 from discord.ext import commands
 
 from .utils.checks import check_guild_exists
-from .utils.db import add_guild
+from .utils.db import add_guild, check_schedule_settings_exists, add_default_schedule_settings
 
 
 logger = logging.getLogger()
@@ -53,6 +53,11 @@ class Initial(commands.Cog):
                 # ADD TO DB IF DOES NOT EXIST
                 logger.info(f'Adding {guild.name} to database.')
                 ok = await add_guild(guild)
+
+            # CHECK THAT IT HAS ASSOCIATED GUILD_SCHEDULE_SETTINGS ENTRY
+            if not await check_schedule_settings_exists(guild.id):
+                logger.info(f"Adding default schedule settings for {guild.name}.")
+                ok = await add_default_schedule_settings(guild.id)
 
         # PRINTS HOW MANY GUILDS / SERVERS THE BOT IS IN.
         logger.info("Snorlax is in " + str(guild_count) + " guilds.")

--- a/cogs/schedules.py
+++ b/cogs/schedules.py
@@ -26,9 +26,9 @@ from .utils import views as snorlax_views
 load_dotenv(find_dotenv())
 DEFAULT_OPEN_MESSAGE = os.getenv('DEFAULT_OPEN_MESSAGE')
 DEFAULT_CLOSE_MESSAGE = os.getenv('DEFAULT_CLOSE_MESSAGE')
-WARNING_TIME = int(os.getenv('WARNING_TIME'))
-INACTIVE_TIME = int(os.getenv('INACTIVE_TIME'))
-DELAY_TIME = int(os.getenv('DELAY_TIME'))
+DEFAULT_WARNING_TIME = int(os.getenv('DEFAULT_WARNING_TIME'))
+DEFAULT_INACTIVE_TIME = int(os.getenv('DEFAULT_INACTIVE_TIME'))
+DEFAULT_DELAY_TIME = int(os.getenv('DEFAULT_DELAY_TIME'))
 
 logger = logging.getLogger()
 
@@ -1399,6 +1399,154 @@ class Schedules(commands.GroupCog, name='schedules'):
 
         await interaction.response.send_message(embed=embed)
 
+    @app_commands.command(
+        name='set-server-open-message',
+        description=(
+            "Sets the default open message that is included in every channel open message."
+        ),
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(snorlax_checks.interaction_check_bot)
+    @app_commands.check(snorlax_checks.check_admin_channel)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_server_open_message(self, interaction: discord.Interaction, open_message: str) -> None:
+        """Sets the default open message that is included in every channel open message.
+
+        Args:
+            interaction: The interaction that triggered the request.
+            open_message: The message to use in the open message. Must be 60 characters or less.
+
+        Returns:
+            None
+        """
+        if len(open_message) > 60:
+            await interaction.response.send_message(
+                "The open message must be less than 60 characters.",
+                ephemeral=True
+            )
+            return
+
+        ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'base_open_message', open_message)
+
+        await interaction.response.send_message(f"Open message updated to:\n```{open_message}```")
+
+    @app_commands.command(
+        name='set-server-close-message',
+        description=(
+            "Sets the default close message that is included in every channel close message."
+        ),
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(snorlax_checks.interaction_check_bot)
+    @app_commands.check(snorlax_checks.check_admin_channel)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_server_close_message(self, interaction: discord.Interaction, close_message: str) -> None:
+        """Sets the default close message that is included in every channel close message.
+
+        Args:
+            interaction: The interaction that triggered the request.
+            close_message: The message to use in the close message. Must be 60 characters or less.
+
+        Returns:
+            None
+        """
+        if len(close_message) > 60:
+            await interaction.response.send_message(
+                "The close message must be less than 60 characters.",
+                ephemeral=True
+            )
+            return
+
+        ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'base_close_message', close_message)
+
+        await interaction.response.send_message(f"Close message updated to:\n```{close_message}```")
+
+    @app_commands.command(
+        name='set-server-warning-time',
+        description=(
+            "Sets the number of minutes before a channel closing that a warning is sent."
+        ),
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(snorlax_checks.interaction_check_bot)
+    @app_commands.check(snorlax_checks.check_admin_channel)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_server_warning_time(
+        self,
+        interaction: discord.Interaction,
+        warning_mins: app_commands.Range[int, 1, 60]
+    ) -> None:
+        """Updates the warning_time in the guild_schedule_settings db table.
+
+        Args:
+            interaction: The interaction that triggered the request.
+            warning_mins: The number of minutes before closure a warning is issued. Must be between 1 and 60.
+
+        Returns:
+            None
+        """
+        ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'warning_time', warning_mins)
+
+        await interaction.response.send_message(f"Warning time updated to {warning_mins} min(s).")
+
+    # @app_commands.command(
+    #     name='set-server-inactive-time',
+    #     description=(
+    #         "Sets the number of minutes since the last message after which the channel is considered inactive."
+    #     ),
+    # )
+    # @app_commands.default_permissions(administrator=True)
+    # @app_commands.check(snorlax_checks.interaction_check_bot)
+    # @app_commands.check(snorlax_checks.check_admin_channel)
+    # @app_commands.checks.has_permissions(administrator=True)
+    # async def set_server_inactive_time(
+    #     self,
+    #     interaction: discord.Interaction,
+    #     inactive_mins: app_commands.Range[int, 1, 120]
+    # ) -> None:
+    #     """Updates the inactive_time in the guild_schedule_settings db table.
+
+    #     Args:
+    #         interaction: The interaction that triggered the request.
+    #         inactive_mins: The number of minutes since the last message was sent to a channel for it to be considered
+    #             inactive. Must be between 1 and 120.
+
+    #     Returns:
+    #         None
+    #     """
+    #     ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'inactive_time', inactive_mins)
+
+    #     await interaction.response.send_message(f"Inactive time updated to {inactive_mins} min(s).")
+
+    # @app_commands.command(
+    #     name='set-server-delay-time',
+    #     description=(
+    #         "Sets the number of minutes closure is delayed if the channel is still active."
+    #     ),
+    # )
+    # @app_commands.default_permissions(administrator=True)
+    # @app_commands.check(snorlax_checks.interaction_check_bot)
+    # @app_commands.check(snorlax_checks.check_admin_channel)
+    # @app_commands.checks.has_permissions(administrator=True)
+    # async def set_server_inactive_time(
+    #     self,
+    #     interaction: discord.Interaction,
+    #     delay_mins: app_commands.Range[int, 1, 30]
+    # ) -> None:
+    #     """Updates the delay_time in the guild_schedule_settings db table.
+
+    #     Args:
+    #         interaction: The interaction that triggered the request.
+    #         delay_mins: the number of minutes closure is delayed if the channel is still active.
+    #             Must be between 1 and 30.
+
+    #     Returns:
+    #         None
+    #     """
+    #     ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'delay_time', delay_mins)
+
+    #     await interaction.response.send_message(f"Delay time updated to {delay_mins} min(s).")
+
     @commands.Cog.listener()
     async def on_guild_channel_update(self, before: GuildChannel, after: GuildChannel) -> None:
         """Updates the channel name in the schedules db upon an edit.
@@ -1544,13 +1692,13 @@ class Schedules(commands.GroupCog, name='schedules'):
                 close_hour, close_min = row.close.split(":")
 
                 if row.warning:
-                    then = now_utc - datetime.timedelta(minutes=INACTIVE_TIME)
+                    then = now_utc - datetime.timedelta(minutes=DEFAULT_INACTIVE_TIME)
 
                     warning = (
                         datetime.datetime(
                             10, 10, 10,
                             hour=int(close_hour), minute=int(close_min)
-                        ) - datetime.timedelta(minutes=WARNING_TIME)
+                        ) - datetime.timedelta(minutes=DEFAULT_WARNING_TIME)
                     ).strftime("%H:%M")
 
                     if warning == now_compare:
@@ -1596,7 +1744,7 @@ class Schedules(commands.GroupCog, name='schedules'):
 
                         continue
 
-                    then = now_utc - datetime.timedelta(minutes=INACTIVE_TIME)
+                    then = now_utc - datetime.timedelta(minutes=DEFAULT_INACTIVE_TIME)
 
                     messages = [message async for message in channel.history(after=then)]
 
@@ -1606,7 +1754,7 @@ class Schedules(commands.GroupCog, name='schedules'):
                         and row.current_delay_num < row.max_num_delays
                     ):
                         new_close_time = (
-                            now + datetime.timedelta(minutes=DELAY_TIME)
+                            now + datetime.timedelta(minutes=DEFAULT_DELAY_TIME)
                         ).strftime("%H:%M")
 
                         await snorlax_db.update_dynamic_close(row.rowid, new_close_time=new_close_time)

--- a/cogs/schedules.py
+++ b/cogs/schedules.py
@@ -1526,9 +1526,9 @@ class Schedules(commands.GroupCog, name='schedules'):
                         raise ValueError(f'Schedule settings not found for guild {guild_id}!')
                     guild_schedule_settings = guild_schedule_settings.iloc[0]
 
-                    warning_time = guild_schedule_settings['warning_time']
-                    inactive_time = guild_schedule_settings['inactive_time']
-                    delay_time = guild_schedule_settings['delay_time']
+                    warning_time = int(guild_schedule_settings['warning_time'])
+                    inactive_time = int(guild_schedule_settings['inactive_time'])
+                    delay_time = int(guild_schedule_settings['delay_time'])
 
                 channel = self.bot.get_channel(row.channel)
                 role = get(channel.guild.roles, id=row.role)

--- a/cogs/schedules.py
+++ b/cogs/schedules.py
@@ -1644,7 +1644,7 @@ class Schedules(commands.GroupCog, name='schedules'):
                                 channel,
                                 tz,
                                 'delay',
-                                DELAY_TIME,
+                                delay_time,
                                 row.current_delay_num + 1,
                                 row.max_num_delays
                             )
@@ -1692,7 +1692,7 @@ class Schedules(commands.GroupCog, name='schedules'):
 
                         continue
 
-                    then = now_utc - datetime.timedelta(minutes=INACTIVE_TIME)
+                    then = now_utc - datetime.timedelta(minutes=inactive_time)
 
                     messages = [message async for message in channel.history(after=then)]
 
@@ -1701,7 +1701,7 @@ class Schedules(commands.GroupCog, name='schedules'):
                         and row.current_delay_num < row.max_num_delays
                     ):
                         new_close_time = (
-                            now + datetime.timedelta(minutes=DELAY_TIME)
+                            now + datetime.timedelta(minutes=delay_time)
                         ).strftime("%H:%M")
 
                         await snorlax_db.update_dynamic_close(row.rowid, new_close_time=new_close_time)
@@ -1712,7 +1712,7 @@ class Schedules(commands.GroupCog, name='schedules'):
                                 channel,
                                 tz,
                                 'delay',
-                                DELAY_TIME,
+                                delay_time,
                                 row.current_delay_num + 1,
                                 row.max_num_delays
                             )
@@ -1730,7 +1730,9 @@ class Schedules(commands.GroupCog, name='schedules'):
                                 client_user,
                                 time_format_fill,
                                 False,
-                                True
+                                True,
+                                delay_time,
+                                warning_time
                             )
 
                             await channel.send(embed=warning_embed)

--- a/cogs/schedules.py
+++ b/cogs/schedules.py
@@ -1585,7 +1585,6 @@ class Schedules(commands.GroupCog, name='schedules'):
                         if snorlax_checks.check_if_channel_active(messages, client_user):
                             warning_embed = snorlax_embeds.get_warning_embed(
                                 row['close'],
-                                now_utc,
                                 client_user,
                                 time_format_fill,
                                 row['dynamic'],
@@ -1728,7 +1727,6 @@ class Schedules(commands.GroupCog, name='schedules'):
                         if row.current_delay_num + 1 == row.max_num_delays:
                             warning_embed = snorlax_embeds.get_warning_embed(
                                 row['dynamic_close'],
-                                now_utc,
                                 client_user,
                                 time_format_fill,
                                 False,

--- a/cogs/schedules.py
+++ b/cogs/schedules.py
@@ -1172,11 +1172,20 @@ class Schedules(commands.GroupCog, name='schedules'):
         Returns:
             None
         """
+        guild_id = channel.guild.id
+
+        guild_schedule_settings = await snorlax_db.load_guild_schedule_settings(guild_id)
+        if guild_schedule_settings.empty:
+            raise ValueError(f'No schedule settings found for guild {channel.guild.name}!')
+        else:
+            guild_close_message = guild_schedule_settings.iloc[0]['base_close_message']
+
         now = snorlax_utils.get_current_time(tz=tz)
 
         close_embed = snorlax_embeds.get_close_embed(
             open,
             now,
+            guild_close_message,
             custom_close_message,
             client_user,
             time_format_fill
@@ -1239,6 +1248,14 @@ class Schedules(commands.GroupCog, name='schedules'):
         Returns:
             None
         """
+        guild_id = channel.guild.id
+
+        guild_schedule_settings = await snorlax_db.load_guild_schedule_settings(guild_id)
+        if guild_schedule_settings.empty:
+            raise ValueError(f'No schedule settings found for guild {channel.guild.name}!')
+        else:
+            guild_open_message = guild_schedule_settings.iloc[0]['base_open_message']
+
         now = snorlax_utils.get_current_time(tz=tz)
         overwrites.send_messages = None
         overwrites.send_messages_in_threads = None
@@ -1247,6 +1264,7 @@ class Schedules(commands.GroupCog, name='schedules'):
         open_embed = snorlax_embeds.get_open_embed(
             close,
             now,
+            guild_open_message,
             custom_open_message,
             client_user,
             time_format_fill
@@ -1399,154 +1417,6 @@ class Schedules(commands.GroupCog, name='schedules'):
 
         await interaction.response.send_message(embed=embed)
 
-    @app_commands.command(
-        name='set-server-open-message',
-        description=(
-            "Sets the default open message that is included in every channel open message."
-        ),
-    )
-    @app_commands.default_permissions(administrator=True)
-    @app_commands.check(snorlax_checks.interaction_check_bot)
-    @app_commands.check(snorlax_checks.check_admin_channel)
-    @app_commands.checks.has_permissions(administrator=True)
-    async def set_server_open_message(self, interaction: discord.Interaction, open_message: str) -> None:
-        """Sets the default open message that is included in every channel open message.
-
-        Args:
-            interaction: The interaction that triggered the request.
-            open_message: The message to use in the open message. Must be 60 characters or less.
-
-        Returns:
-            None
-        """
-        if len(open_message) > 60:
-            await interaction.response.send_message(
-                "The open message must be less than 60 characters.",
-                ephemeral=True
-            )
-            return
-
-        ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'base_open_message', open_message)
-
-        await interaction.response.send_message(f"Open message updated to:\n```{open_message}```")
-
-    @app_commands.command(
-        name='set-server-close-message',
-        description=(
-            "Sets the default close message that is included in every channel close message."
-        ),
-    )
-    @app_commands.default_permissions(administrator=True)
-    @app_commands.check(snorlax_checks.interaction_check_bot)
-    @app_commands.check(snorlax_checks.check_admin_channel)
-    @app_commands.checks.has_permissions(administrator=True)
-    async def set_server_close_message(self, interaction: discord.Interaction, close_message: str) -> None:
-        """Sets the default close message that is included in every channel close message.
-
-        Args:
-            interaction: The interaction that triggered the request.
-            close_message: The message to use in the close message. Must be 60 characters or less.
-
-        Returns:
-            None
-        """
-        if len(close_message) > 60:
-            await interaction.response.send_message(
-                "The close message must be less than 60 characters.",
-                ephemeral=True
-            )
-            return
-
-        ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'base_close_message', close_message)
-
-        await interaction.response.send_message(f"Close message updated to:\n```{close_message}```")
-
-    @app_commands.command(
-        name='set-server-warning-time',
-        description=(
-            "Sets the number of minutes before a channel closing that a warning is sent."
-        ),
-    )
-    @app_commands.default_permissions(administrator=True)
-    @app_commands.check(snorlax_checks.interaction_check_bot)
-    @app_commands.check(snorlax_checks.check_admin_channel)
-    @app_commands.checks.has_permissions(administrator=True)
-    async def set_server_warning_time(
-        self,
-        interaction: discord.Interaction,
-        warning_mins: app_commands.Range[int, 1, 60]
-    ) -> None:
-        """Updates the warning_time in the guild_schedule_settings db table.
-
-        Args:
-            interaction: The interaction that triggered the request.
-            warning_mins: The number of minutes before closure a warning is issued. Must be between 1 and 60.
-
-        Returns:
-            None
-        """
-        ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'warning_time', warning_mins)
-
-        await interaction.response.send_message(f"Warning time updated to {warning_mins} min(s).")
-
-    # @app_commands.command(
-    #     name='set-server-inactive-time',
-    #     description=(
-    #         "Sets the number of minutes since the last message after which the channel is considered inactive."
-    #     ),
-    # )
-    # @app_commands.default_permissions(administrator=True)
-    # @app_commands.check(snorlax_checks.interaction_check_bot)
-    # @app_commands.check(snorlax_checks.check_admin_channel)
-    # @app_commands.checks.has_permissions(administrator=True)
-    # async def set_server_inactive_time(
-    #     self,
-    #     interaction: discord.Interaction,
-    #     inactive_mins: app_commands.Range[int, 1, 120]
-    # ) -> None:
-    #     """Updates the inactive_time in the guild_schedule_settings db table.
-
-    #     Args:
-    #         interaction: The interaction that triggered the request.
-    #         inactive_mins: The number of minutes since the last message was sent to a channel for it to be considered
-    #             inactive. Must be between 1 and 120.
-
-    #     Returns:
-    #         None
-    #     """
-    #     ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'inactive_time', inactive_mins)
-
-    #     await interaction.response.send_message(f"Inactive time updated to {inactive_mins} min(s).")
-
-    # @app_commands.command(
-    #     name='set-server-delay-time',
-    #     description=(
-    #         "Sets the number of minutes closure is delayed if the channel is still active."
-    #     ),
-    # )
-    # @app_commands.default_permissions(administrator=True)
-    # @app_commands.check(snorlax_checks.interaction_check_bot)
-    # @app_commands.check(snorlax_checks.check_admin_channel)
-    # @app_commands.checks.has_permissions(administrator=True)
-    # async def set_server_inactive_time(
-    #     self,
-    #     interaction: discord.Interaction,
-    #     delay_mins: app_commands.Range[int, 1, 30]
-    # ) -> None:
-    #     """Updates the delay_time in the guild_schedule_settings db table.
-
-    #     Args:
-    #         interaction: The interaction that triggered the request.
-    #         delay_mins: the number of minutes closure is delayed if the channel is still active.
-    #             Must be between 1 and 30.
-
-    #     Returns:
-    #         None
-    #     """
-    #     ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'delay_time', delay_mins)
-
-    #     await interaction.response.send_message(f"Delay time updated to {delay_mins} min(s).")
-
     @commands.Cog.listener()
     async def on_guild_channel_update(self, before: GuildChannel, after: GuildChannel) -> None:
         """Updates the channel name in the schedules db upon an edit.
@@ -1651,6 +1521,15 @@ class Schedules(commands.GroupCog, name='schedules'):
                         time_format_fill = "Unavailable"
                     last_guild_id = guild_id
 
+                    guild_schedule_settings = await snorlax_db.load_guild_schedule_settings(guild_id)
+                    if guild_schedule_settings.empty:
+                        raise ValueError(f'Schedule settings not found for guild {guild_id}!')
+                    guild_schedule_settings = guild_schedule_settings.iloc[0]
+
+                    warning_time = guild_schedule_settings['warning_time']
+                    inactive_time = guild_schedule_settings['inactive_time']
+                    delay_time = guild_schedule_settings['delay_time']
+
                 channel = self.bot.get_channel(row.channel)
                 role = get(channel.guild.roles, id=row.role)
                 # get current overwrites
@@ -1692,13 +1571,13 @@ class Schedules(commands.GroupCog, name='schedules'):
                 close_hour, close_min = row.close.split(":")
 
                 if row.warning:
-                    then = now_utc - datetime.timedelta(minutes=DEFAULT_INACTIVE_TIME)
+                    then = now_utc - datetime.timedelta(minutes=inactive_time)
 
                     warning = (
                         datetime.datetime(
                             10, 10, 10,
                             hour=int(close_hour), minute=int(close_min)
-                        ) - datetime.timedelta(minutes=DEFAULT_WARNING_TIME)
+                        ) - datetime.timedelta(minutes=warning_time)
                     ).strftime("%H:%M")
 
                     if warning == now_compare:
@@ -1744,7 +1623,7 @@ class Schedules(commands.GroupCog, name='schedules'):
 
                         continue
 
-                    then = now_utc - datetime.timedelta(minutes=DEFAULT_INACTIVE_TIME)
+                    then = now_utc - datetime.timedelta(minutes=inactive_time)
 
                     messages = [message async for message in channel.history(after=then)]
 
@@ -1754,7 +1633,7 @@ class Schedules(commands.GroupCog, name='schedules'):
                         and row.current_delay_num < row.max_num_delays
                     ):
                         new_close_time = (
-                            now + datetime.timedelta(minutes=DEFAULT_DELAY_TIME)
+                            now + datetime.timedelta(minutes=delay_time)
                         ).strftime("%H:%M")
 
                         await snorlax_db.update_dynamic_close(row.rowid, new_close_time=new_close_time)
@@ -1895,6 +1774,197 @@ class Schedules(commands.GroupCog, name='schedules'):
         await asyncio.sleep(sleep_time)
 
 
+@app_commands.default_permissions(administrator=True)
+class SchedulesSettings(commands.GroupCog, name='schedules-settings'):
+    """
+    The schedules settings group that contains commands to set
+    the settings that apply to all schedules.
+    """
+    def __init__(self, bot: commands.bot) -> None:
+        """
+        Init method for schedules settings.
+
+        Args:
+            bot: The discord.py bot representation.
+
+        Returns:
+            None.
+        """
+        super(SchedulesSettings, self).__init__()
+        self.bot = bot
+
+    async def cog_check(self, ctx: commands.context) -> bool:
+        """
+        Defines the checks to perform on the received command for all the
+        commands in the cog.
+
+        Args:
+            ctx: The command context containing the message content and other
+                metadata.
+
+        Returns:
+            bool: True of False for whether the checks pass or fail,
+                respectively.
+        """
+        admin_check = snorlax_checks.check_admin(ctx)
+        bot_check = snorlax_checks.check_bot(ctx)
+
+        if not bot_check:
+            return False
+
+        if admin_check:
+            return True
+        else:
+            return False
+
+    @app_commands.command(
+        name='set-server-open-message',
+        description=(
+            "Sets the default open message that is included in every channel open message."
+        ),
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(snorlax_checks.interaction_check_bot)
+    @app_commands.check(snorlax_checks.check_admin_channel)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_server_open_message(self, interaction: discord.Interaction, open_message: str) -> None:
+        """Sets the default open message that is included in every channel open message.
+
+        Args:
+            interaction: The interaction that triggered the request.
+            open_message: The message to use in the open message. Must be 60 characters or less.
+
+        Returns:
+            None
+        """
+        if len(open_message) > 60:
+            await interaction.response.send_message(
+                "The open message must be less than 60 characters.",
+                ephemeral=True
+            )
+            return
+
+        ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'base_open_message', open_message)
+
+        await interaction.response.send_message(f"Open message updated to:\n```{open_message}```")
+
+    @app_commands.command(
+        name='set-server-close-message',
+        description=(
+            "Sets the default close message that is included in every channel close message."
+        ),
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(snorlax_checks.interaction_check_bot)
+    @app_commands.check(snorlax_checks.check_admin_channel)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_server_close_message(self, interaction: discord.Interaction, close_message: str) -> None:
+        """Sets the default close message that is included in every channel close message.
+
+        Args:
+            interaction: The interaction that triggered the request.
+            close_message: The message to use in the close message. Must be 60 characters or less.
+
+        Returns:
+            None
+        """
+        if len(close_message) > 60:
+            await interaction.response.send_message(
+                "The close message must be less than 60 characters.",
+                ephemeral=True
+            )
+            return
+
+        ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'base_close_message', close_message)
+
+        await interaction.response.send_message(f"Close message updated to:\n```{close_message}```")
+
+    @app_commands.command(
+        name='set-server-warning-time',
+        description=(
+            "Sets the number of minutes before a channel closing that a warning is sent."
+        ),
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(snorlax_checks.interaction_check_bot)
+    @app_commands.check(snorlax_checks.check_admin_channel)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_server_warning_time(
+        self,
+        interaction: discord.Interaction,
+        warning_mins: app_commands.Range[int, 1, 60]
+    ) -> None:
+        """Updates the warning_time in the guild_schedule_settings db table.
+
+        Args:
+            interaction: The interaction that triggered the request.
+            warning_mins: The number of minutes before closure a warning is issued. Must be between 1 and 60.
+
+        Returns:
+            None
+        """
+        ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'warning_time', warning_mins)
+
+        await interaction.response.send_message(f"Warning time updated to {warning_mins} min(s).")
+
+    @app_commands.command(
+        name='set-server-inactive-time',
+        description=(
+            "Sets the number of minutes since the last message after which the channel is considered inactive."
+        ),
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(snorlax_checks.interaction_check_bot)
+    @app_commands.check(snorlax_checks.check_admin_channel)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_server_inactive_time(
+        self,
+        interaction: discord.Interaction,
+        inactive_mins: app_commands.Range[int, 1, 120]
+    ) -> None:
+        """Updates the inactive_time in the guild_schedule_settings db table.
+
+        Args:
+            interaction: The interaction that triggered the request.
+            inactive_mins: The number of minutes since the last message was sent for channel to be considered
+                inactive.
+
+        Returns:
+            None
+        """
+        ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'inactive_time', inactive_mins)
+
+        await interaction.response.send_message(f"Inactive time updated to {inactive_mins} min(s).")
+
+    @app_commands.command(
+        name='set-server-delay-time',
+        description=(
+            "Sets the number of minutes closure is delayed if the channel is still active."
+        ),
+    )
+    @app_commands.default_permissions(administrator=True)
+    @app_commands.check(snorlax_checks.interaction_check_bot)
+    @app_commands.check(snorlax_checks.check_admin_channel)
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_server_delay_time(
+        self,
+        interaction: discord.Interaction,
+        delay_mins: app_commands.Range[int, 1, 30]
+    ) -> None:
+        """Updates the delay_time in the guild_schedule_settings db table.
+
+        Args:
+            interaction: The interaction that triggered the request.
+            delay_mins: The number of minutes closure is delayed if the channel is still active.
+
+        Returns:
+            None
+        """
+        ok = await snorlax_db.update_guild_schedule_settings(interaction.guild.id, 'delay_time', delay_mins)
+
+        await interaction.response.send_message(f"Delay time updated to {delay_mins} min(s).")
+
+
 async def setup(bot: commands.bot) -> None:
     """The setup function to initiate the cog.
 
@@ -1906,5 +1976,10 @@ async def setup(bot: commands.bot) -> None:
             Schedules(bot),
             guild=discord.Object(id=bot.test_guild)
         )
+        await bot.add_cog(
+            SchedulesSettings(bot),
+            guild=discord.Object(id=bot.test_guild)
+        )
     else:
         await bot.add_cog(Schedules(bot))
+        await bot.add_cog(SchedulesSettings(bot))

--- a/cogs/schedules.py
+++ b/cogs/schedules.py
@@ -1589,7 +1589,9 @@ class Schedules(commands.GroupCog, name='schedules'):
                                 client_user,
                                 time_format_fill,
                                 row['dynamic'],
-                                False
+                                False,
+                                delay_time,
+                                warning_time
                             )
 
                             await channel.send(embed=warning_embed)

--- a/cogs/utils/db.py
+++ b/cogs/utils/db.py
@@ -70,7 +70,7 @@ async def _get_guild_schedule_settings(guild_id: int) -> tuple[tuple[Any], tuple
     async with aiosqlite.connect(DATABASE) as db:
         async with db.execute(f'PRAGMA table_info(guild_schedule_settings);') as cursor:
             columns = [i[1] for i in await cursor.fetchall()]
-        query = "SELECT * FROM guild_schedules_settings WHERE guild = ?"
+        query = "SELECT * FROM guild_schedule_settings WHERE guild = ?"
         async with db.execute(query, (guild_id,)) as cursor:
             rows = await cursor.fetchall()
 

--- a/cogs/utils/db.py
+++ b/cogs/utils/db.py
@@ -14,6 +14,11 @@ load_dotenv(find_dotenv())
 DATABASE = os.getenv('DATABASE')
 DEFAULT_TZ = os.getenv('DEFAULT_TZ')
 DEFAULT_PREFIX = os.getenv('DEFAULT_PREFIX')
+DEFAULT_OPEN_MESSAGE = os.getenv('DEFAULT_OPEN_MESSAGE')
+DEFAULT_CLOSE_MESSAGE = os.getenv('DEFAULT_CLOSE_MESSAGE')
+DEFAULT_WARNING_TIME = os.getenv('DEFAULT_WARNING_TIME')
+DEFAULT_INACTIVE_TIME = os.getenv('DEFAULT_INACTIVE_TIME')
+DEFAULT_DELAY_TIME = os.getenv('DEFAULT_DELAY_TIME')
 
 
 async def _get_schedule_db() -> tuple[tuple[Any], tuple[str]]:
@@ -47,6 +52,26 @@ async def _get_single_schedule(rowid: int) -> tuple[tuple[Any], tuple[str]]:
             columns = ['rowid'] + [i[1] for i in await cursor.fetchall()]
         query = "SELECT rowid, * FROM schedules WHERE rowid = ?"
         async with db.execute(query, (rowid,)) as cursor:
+            rows = await cursor.fetchall()
+
+    return rows, columns
+
+
+async def _get_guild_schedule_settings(guild_id: int) -> tuple[tuple[Any], tuple[str]]:
+    """Gets the settings row from the guild schedule settings database table.
+
+    Args:
+        guild_id: The guild to fetch.
+
+    Returns:
+        The rows of the database table.
+        The columns of the database table.
+    """
+    async with aiosqlite.connect(DATABASE) as db:
+        async with db.execute(f'PRAGMA table_info(guild_schedule_settings);') as cursor:
+            columns = [i[1] for i in await cursor.fetchall()]
+        query = "SELECT * FROM guild_schedules_settings WHERE guild = ?"
+        async with db.execute(query, (guild_id,)) as cursor:
             rows = await cursor.fetchall()
 
     return rows, columns
@@ -128,6 +153,21 @@ async def load_schedule_db(
             schedules = schedules.loc[~schedules['active']]
 
     return schedules
+
+
+async def load_guild_schedule_settings(guild_id: int) -> pd.DataFrame:
+    """Loads the guild_schedule_settings for the required guild.
+
+    Args:
+        guild_id: The guild to load.
+
+    Returns:
+        A pandas dataframe containing the settings.
+    """
+    rows, columns = await _get_guild_schedule_settings(guild_id)
+    guild_schedule_settings = pd.DataFrame(rows, columns=columns)
+
+    return guild_schedule_settings
 
 
 async def load_friend_code_channels_db() -> pd.DataFrame:
@@ -961,3 +1001,85 @@ async def get_guild_raid_category(guild_id: int) -> bool:
             raid_category = await cursor.fetchone()
 
     return raid_category[0]
+
+
+async def check_schedule_settings_exists(guild_id: int) -> bool:
+    """Checks whether an entry exists for the guild in the guild_schedule_settings db.
+
+    Args:
+        guild_id: The guild id to check.
+
+    Returns:
+        'True' if exists, 'False' if not.
+    """
+    async with aiosqlite.connect(DATABASE) as db:
+        query = "SELECT EXISTS(SELECT 1 FROM guild_schedule_settings WHERE guild = ?)"
+        async with db.execute(query, (guild_id,)) as cursor:
+            exists = await cursor.fetchone()
+
+    return bool(exists[0])
+
+
+async def add_default_schedule_settings(guild_id: int) -> bool:
+    """Enters a row into the guild_schedule_settings table with default settings.
+
+    Args:
+        guild_id: The guild to enter.
+
+    Returns:
+        'True' if entry was successful, 'False' if not.
+    """
+    try:
+        async with aiosqlite.connect(DATABASE) as db:
+            sql_command = (
+                "INSERT INTO guild_schedule_settings(guild, base_open_message, base_close_message, warning_time, "
+                "inactive_time, delay_time) VALUES (?, ?, ?, ?, ?, ?)"
+            )
+            params = (
+                guild_id,
+                DEFAULT_OPEN_MESSAGE,
+                DEFAULT_CLOSE_MESSAGE,
+                DEFAULT_WARNING_TIME,
+                DEFAULT_INACTIVE_TIME,
+                DEFAULT_DELAY_TIME
+            )
+            await db.execute(sql_command, params)
+            await db.commit()
+
+        return True
+
+    except Exception as e:
+        logger.error(e)
+        return False
+
+
+async def update_guild_schedule_settings(
+    guild_id: int,
+    column: str,
+    value: Union[str, bool, int]
+) -> bool:
+    """
+    Update a parameter of the guild schedule settings db.
+
+    Currently entered columns must be valid before use. No checks are
+    performed in the method itself.
+
+    Args:
+        guild_id: The guild_id to update.
+        column: The column name, or key, of the value to update.
+        value: The value to set.
+
+    Returns:
+        A bool to signify that the database transaction was successful
+        ('True') or not ('False').
+    """
+    try:
+        async with aiosqlite.connect(DATABASE) as db:
+            sql_command = f"UPDATE guild_schedule_settings SET {column} = ? WHERE guild = ?"
+            await db.execute(sql_command, (value, guild_id))
+            await db.commit()
+
+        return True
+
+    except Exception as e:
+        return False

--- a/cogs/utils/embeds.py
+++ b/cogs/utils/embeds.py
@@ -374,16 +374,9 @@ def get_warning_embed(
     else:
         warning_string += " at"
 
-    embed.add_field(
-        name=warning_string,
-        value=f"{close_time_str} {now.tzname()}"
-    )
+    embed.add_field(name=warning_string, value=f"{close_time_str}")
 
-    embed.add_field(
-        name="Current Time",
-        value=time_format_fill,
-        inline=False
-    )
+    embed.add_field(name="Current Time", value=time_format_fill, inline=False)
 
     if dynamic:
         embed.add_field(

--- a/cogs/utils/embeds.py
+++ b/cogs/utils/embeds.py
@@ -14,9 +14,9 @@ from typing import Union
 load_dotenv(find_dotenv())
 DEFAULT_OPEN_MESSAGE = os.getenv('DEFAULT_OPEN_MESSAGE')
 DEFAULT_CLOSE_MESSAGE = os.getenv('DEFAULT_CLOSE_MESSAGE')
-WARNING_TIME = os.getenv('WARNING_TIME')
-INACTIVE_TIME = os.getenv('INACTIVE_TIME')
-DELAY_TIME = os.getenv('DELAY_TIME')
+DEFAULT_WARNING_TIME = os.getenv('DEFAULT_WARNING_TIME')
+DEFAULT_INACTIVE_TIME = os.getenv('DEFAULT_INACTIVE_TIME')
+DEFAULT_DELAY_TIME = os.getenv('DEFAULT_DELAY_TIME')
 
 
 def get_schedule_embed(schedule_db: pd.DataFrame, num_warning_roles: int = 0) -> Embed:

--- a/cogs/utils/embeds.py
+++ b/cogs/utils/embeds.py
@@ -297,6 +297,7 @@ def get_close_embed(
     Args:
         open: The string representation of the future opening time, e.g. '12:00'.
         now: The datetime object of the closing time.
+        base_close_message: The guild base close message.
         custom_close_message: The custom close message of the schedule.
         client_user: The bot user object.
         time_format_fill: The string time channel mention, or 'Unavailable' if the time channel
@@ -335,7 +336,6 @@ def get_close_embed(
 
 def get_warning_embed(
     close: str,
-    now: datetime.datetime,
     client_user: discord.User,
     time_format_fill: str,
     dynamic: bool,
@@ -347,13 +347,14 @@ def get_warning_embed(
 
     Args:
         close: The string representation of the future closing time, e.g. '12:00'.
-        now: The datetime object of the warning time.
         client_user: The bot user object.
         time_format_fill: The string time channel mention, or 'Unavailable' if the time channel
             is not configured.
         dynamic: Whether dynamic mode is activated on the schedule (True) or not (False).
         delay: Whether the warning is because of a previous delay. No dynamic addition
             will be made if True.
+        delay_time: The guild delay time in minutes.
+        warning_time: The guild warning time in minutes.
 
     Returns:
         The warning embed containing the next close time and the current time.

--- a/cogs/utils/embeds.py
+++ b/cogs/utils/embeds.py
@@ -339,7 +339,9 @@ def get_warning_embed(
     client_user: discord.User,
     time_format_fill: str,
     dynamic: bool,
-    delay: bool
+    delay: bool,
+    delay_time: int,
+    warning_time: int
 ) -> Embed:
     """Produces the warning embed that is sent when a is to close and warnings are enabled.
 
@@ -363,7 +365,7 @@ def get_warning_embed(
 
     close_time_str = datetime.datetime.strptime(close, '%H:%M').strftime('%I:%M %p')
 
-    buffer_time = DELAY_TIME if delay else WARNING_TIME
+    buffer_time = delay_time if delay else warning_time
 
     warning_string = f"Channel is due to close in {buffer_time} minute"
 

--- a/cogs/utils/utils.py
+++ b/cogs/utils/utils.py
@@ -18,9 +18,9 @@ from typing import Callable, Optional
 load_dotenv(find_dotenv())
 DEFAULT_OPEN_MESSAGE = os.getenv('DEFAULT_OPEN_MESSAGE')
 DEFAULT_CLOSE_MESSAGE = os.getenv('DEFAULT_CLOSE_MESSAGE')
-WARNING_TIME = os.getenv('WARNING_TIME')
-INACTIVE_TIME = os.getenv('INACTIVE_TIME')
-DELAY_TIME = os.getenv('DELAY_TIME')
+DEFAULT_WARNING_TIME = os.getenv('DEFAULT_WARNING_TIME')
+DEFAULT_INACTIVE_TIME = os.getenv('DEFAULT_INACTIVE_TIME')
+DEFAULT_DELAY_TIME = os.getenv('DEFAULT_DELAY_TIME')
 
 
 def get_current_time(tz: str) -> datetime.datetime:


### PR DESCRIPTION
The following settings have been migrated from the `.env` file to be in a "guild schedule settings" database table such that they can be set per guild:

* The base open message.
* The base close message.
* Warning time.
* Inactive time.
* Delay time.

Fixes #4.