### PR TITLE
Added open and close message deletion on inactivity

### DIFF
--- a/alembic/versions/f8574e25d62d_add_last_message_id_to_close_and_open.py
+++ b/alembic/versions/f8574e25d62d_add_last_message_id_to_close_and_open.py
@@ -1,0 +1,28 @@
+"""add last message id to close and open
+
+Revision ID: f8574e25d62d
+Revises: 9b7158520f28
+Create Date: 2022-09-25 16:52:26.857550
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f8574e25d62d'
+down_revision = '9b7158520f28'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("schedules") as batch_op:
+        batch_op.add_column(sa.Column('last_open_message', sa.Integer))
+        batch_op.add_column(sa.Column('last_close_message', sa.Integer))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("schedules") as batch_op:
+        batch_op.drop_column('last_open_message')
+        batch_op.drop_column('last_close_message')

--- a/cogs/utils/db.py
+++ b/cogs/utils/db.py
@@ -463,8 +463,8 @@ async def create_schedule(
             sql_command = (
                 "INSERT INTO schedules(guild, channel, role, channel_name, role_name, open, close, "
                 "open_message, close_message, warning, dynamic, dynamic_close, max_num_delays, "
-                "current_delay_num, silent, active) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                "current_delay_num, silent, active, last_open_message, last_close_message) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
             )
             params = (
                 guild_id,
@@ -482,7 +482,9 @@ async def create_schedule(
                 max_num_delays,
                 0,
                 silent,
-                True
+                True,
+                0,  # last_open_message
+                0   # last_close_message
             )
             async with db.execute(sql_command, params) as cursor:
                 rowid = cursor.lastrowid
@@ -1083,3 +1085,45 @@ async def update_guild_schedule_settings(
 
     except Exception as e:
         return False
+
+
+async def get_schedule_last_open_message(schedule_id: int) -> str:
+    """
+    Fetches the channel id of the requested schedule.
+
+    Args:
+        schedule_id: The id of the schedule to obtain the close time for.
+
+    Returns:
+        The schedule channel id.
+    """
+    async with aiosqlite.connect(DATABASE) as db:
+        query = "SELECT last_open_message FROM schedules WHERE rowid = ?;"
+        async with db.execute(query, (schedule_id,)) as cursor:
+            last_open_message = await cursor.fetchone()
+
+    if last_open_message is not None:
+        last_open_message = int(last_open_message[0])
+
+    return last_open_message
+
+
+async def get_schedule_last_close_message(schedule_id: int) -> str:
+    """
+    Fetches the channel id of the requested schedule.
+
+    Args:
+        schedule_id: The id of the schedule to obtain the close time for.
+
+    Returns:
+        The schedule channel id.
+    """
+    async with aiosqlite.connect(DATABASE) as db:
+        query = "SELECT last_close_message FROM schedules WHERE rowid = ?;"
+        async with db.execute(query, (schedule_id,)) as cursor:
+            last_close_message = await cursor.fetchone()
+
+    if last_close_message is not None:
+        last_close_message = int(last_close_message[0])
+
+    return last_close_message


### PR DESCRIPTION
- Now record the last open and close message ids in the DB.
- Auto deletes the last messages if no activity has happened in the channel since the last open.

Fixes #73.