### PR TITLE
Added zombie guild check

### DIFF
--- a/cogs/initial.py
+++ b/cogs/initial.py
@@ -108,7 +108,7 @@ class Initial(commands.Cog):
 
         for _, row in schedules_df[['rowid', 'guild', 'channel']].iterrows():
             # If a guild is not active then don't check.
-            if row['guild'] not in guilds_df.index:
+            if row['guild'] not in guilds_df.index.to_numpy():
                 continue
             channel = self.bot.get_channel(row['channel'])
             if channel is None:


### PR DESCRIPTION
- Checks for guild removals in the cases where the bot missed the event for whatever reason.
- Deactivates guild and schedules.
- Delays zombie schedules check to after so that only active guild schedules are checked.

Fixes #102.