### PR TITLE
Added zombie check for friend code channels

### DIFF
--- a/cogs/fc_filter.py
+++ b/cogs/fc_filter.py
@@ -154,7 +154,7 @@ class FriendCodeFilter(commands.GroupCog, name="friend-code-filter"):
             embed = get_message_embed(msg, msg_type='warning')
             ephemeral = True
         else:
-            ok = await snorlax_db.drop_allowed_friend_code_channel(guild, channel)
+            ok = await snorlax_db.drop_allowed_friend_code_channel(guild.id, channel.id)
             if ok:
                 msg = (
                     f"{channel.mention} removed from the friend code"
@@ -289,7 +289,7 @@ class FriendCodeFilter(commands.GroupCog, name="friend-code-filter"):
         fc_channels = await snorlax_db.load_friend_code_channels_db()
 
         if channel.id in fc_channels['channel'].tolist():
-            ok = await snorlax_db.drop_allowed_friend_code_channel(channel.guild, channel)
+            ok = await snorlax_db.drop_allowed_friend_code_channel(channel.guild.id, channel.id)
             if ok:
                 log_channel = await snorlax_db.get_guild_log_channel(channel.guild.id)
                 if log_channel != -1:

--- a/cogs/utils/db.py
+++ b/cogs/utils/db.py
@@ -530,15 +530,17 @@ async def update_schedule(
 
 
 async def drop_allowed_friend_code_channel(
-    guild: Guild,
-    channel: TextChannel
+    guild_id: int,
+    channel_id: int
 ) -> bool:
     """
     Drops a channel from the allowed whitelist.
 
+    Arguments have to be id values in the event of a channel being deleted.
+
     Args:
-        guild: The discord guild object.
-        channel: The discord TextChannel object.
+        guild: The discord guild id.
+        channel: The discord channel id.
 
     Returns:
         A bool to signify that the database transaction was successful
@@ -547,7 +549,7 @@ async def drop_allowed_friend_code_channel(
     try:
         async with aiosqlite.connect(DATABASE) as db:
             sql_query = "SELECT rowid FROM fc_channels WHERE guild = ? AND channel = ?"
-            async with db.execute(sql_query, (guild.id, channel.id)) as cursor:
+            async with db.execute(sql_query, (guild_id, channel_id)) as cursor:
                 async for row in cursor:
                     # row is a tuple of the row id only, e.g. (2,)
                     await cursor.execute("DELETE FROM fc_channels WHERE rowid = ?", row)


### PR DESCRIPTION
Friend code channels are now also checked for zombie entries. This can occur when a channel is deleted and the bot for whatever reason has missed it.

Also changes the drop friend code channel database function to accept the id numbers rather than the guild and channel objects.

Fixes #118.