### PR TITLE
Relax friend code tolerance

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 from cogs.utils.checks import check_admin
 from cogs.utils.utils import get_logger, get_prefix
 
-__version__ = "1.2.0-dev"
+__version__ = "1.1.2"
 DOCS_URL = "placeholder"
 
 

--- a/cogs/utils/checks.py
+++ b/cogs/utils/checks.py
@@ -126,7 +126,7 @@ def check_for_friend_code(content: str) -> bool:
     Returns:
         'True' when the message contains a friend code. 'False' if not.
     """
-    pattern = re.compile(r"\d{4}.*\d{4}.*\d{4}(?!(\d*\>))")
+    pattern = re.compile(r"\d{4}.{0,2}\d{4}.{0,2}\d{4}(?!(\d*\>))")
     content = snorlax_utils.strip_mentions(content)
     content = snorlax_utils.strip_url(content)
     match = re.search(pattern, content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "officer-snorlax-bot"
-version = "1.2.0-dev"
+version = "1.1.2"
 description = "Officer Snorlax Discord bot created to open and close channels on a schedule."
 authors = ["Adam Stewart"]
 license = "MIT"


### PR DESCRIPTION
This relaxes the friend code tolerance to try and avoid messages such as:

```
Those are special case, every person only gets a limited number of those 2016/2017 guaranteed lucky trades. Up to 15 guaranteed lucky trades with them. After that, your 16th trade with a 2016/2017 pokemon is treated the same as any others, capped at 20% lucky chance
```

being filtered out.